### PR TITLE
tracer: default WS protocol to HTTP with override

### DIFF
--- a/src/flow_storm/tracer.cljc
+++ b/src/flow_storm/tracer.cljc
@@ -63,8 +63,9 @@
   "Connects to the flow-storm debugger.
   When connection is ready, replies any events hold in `pre-conn-events-holder`"
   ([] (connect nil))
-  ([{:keys [host port]}]
+  ([{:keys [host port protocol]}]
    (let [{:keys [chsk ch-recv send-fn state]} (sente/make-channel-socket-client! "/chsk"  nil {:type :ws
+                                                                                               :protocol (or protocol "http:")
                                                                                                :host (or host "localhost")
                                                                                                :port (or port 7722)})]
 


### PR DESCRIPTION
Currently if the CLJS version of the tracer is loaded over an HTTPS connection, sente will attempt to establish a WSS connection to the flow-storm server, which only serves WS.

I'm forcing that back to HTTP here (tested, working locally) and allowing users to override it back in case someone wants to proxy their flow-storm server to HTTPS for whatever reason.

In my case this is necessary to use flow-storm at all -- locally I've just copied connect into my own code and modified it, but it would be great to just be able to call `(fsa/connect)`.