### PR TITLE
Added preload for easier shadow-cljs setup

### DIFF
--- a/src/flow_storm/preload.cljs
+++ b/src/flow_storm/preload.cljs
@@ -1,0 +1,4 @@
+(ns flow-storm.preload
+  (:require [flow-storm.api :as fs-api]))
+
+(fs-api/connect)


### PR DESCRIPTION
Currently if I want to include flow-storm on the client I need to write some custom CLJS code in the project before I can send the preload NS to shadow. With this change, I can just pass this to shadow like this:

`clojure -M:shadow watch app --config-merge '{:devtools {:preloads [flow-storm.preload]}}'`